### PR TITLE
Fix "Cannot read property 'nuxtSrcDir' of null" error when config is null

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,10 @@ const path = require('path');
 const log = require('debug')('eslint-plugin-import:resolver:nuxt')
 
 exports.interfaceVersion = 2;
-exports.resolve = function (source, file, config = {}) {
+exports.resolve = function (source, file, config) {
   const trimmedSouce = trimResourceQuery(source)
   log('Resolving: ', trimmedSouce, 'from:', file);
-  const realSource = parseSource(trimmedSouce, config.nuxtSrcDir);
+  const realSource = parseSource(trimmedSouce, config && config.nuxtSrcDir);
 
   if (resolve.isCore(realSource)) {
     log('resolved to core');
@@ -31,8 +31,8 @@ function trimResourceQuery(source) {
   return source
 }
 
-function parseSource(source, srcDir = '') {
-  const nuxtSrcDir = path.join(process.cwd(), srcDir);
+function parseSource(source, srcDir) {
+  const nuxtSrcDir = path.join(process.cwd(), srcDir || '');
   const nuxtAliasRe = /^~(assets|components|pages|plugins|static|store)?\/.+/;
   const nuxtFileAlias = ['~store', '~router'];
 
@@ -50,7 +50,7 @@ function opts(file, config) {
     {
       extensions: ['.mjs', '.js', '.json', '.vue']
     },
-    config,
+    config || {},
     {
       // path.resolve will handle paths relative to CWD
       basedir: path.dirname(path.resolve(file)),


### PR DESCRIPTION
## Problem

When config is `null`, ie the following config is used:

```
    "settings": {
      "import/resolver": "nuxt"
    },
```

ESLint crashes with the following error:

```
❯ yarn lint
yarn run v1.13.0
$ eslint --ext .js,.vue --ignore-path .gitignore .

./nuxt.config.js
  1:1  error  Resolve error: Cannot read property 'nuxtSrcDir' of null  import/order

./pages/index.vue
   1:1   error    Resolve error: Cannot read property 'nuxtSrcDir' of null  import/namespace
   1:1   warning  Resolve error: Cannot read property 'nuxtSrcDir' of null  import/no-duplicates
   1:1   error    Resolve error: Cannot read property 'nuxtSrcDir' of null  import/no-unresolved
   1:1   error    Resolve error: Cannot read property 'nuxtSrcDir' of null  import/default
   1:1   error    Resolve error: Cannot read property 'nuxtSrcDir' of null  import/order
   1:1   warning  Resolve error: Cannot read property 'nuxtSrcDir' of null  import/no-named-as-default
   1:1   warning  Resolve error: Cannot read property 'nuxtSrcDir' of null  import/no-named-as-default-member

./server/index.js
  1:1  error  Resolve error: Cannot read property 'nuxtSrcDir' of null  import/order

./Logo.spec.js
  1:1   error    Resolve error: Cannot read property 'nuxtSrcDir' of null  import/namespace
  1:1   warning  Resolve error: Cannot read property 'nuxtSrcDir' of null  import/no-duplicates
  1:1   error    Resolve error: Cannot read property 'nuxtSrcDir' of null  import/no-unresolved
  1:1   error    Resolve error: Cannot read property 'nuxtSrcDir' of null  import/named
  1:1   error    Resolve error: Cannot read property 'nuxtSrcDir' of null  import/order
  1:1   error    Resolve error: Cannot read property 'nuxtSrcDir' of null  import/default
  1:1   warning  Resolve error: Cannot read property 'nuxtSrcDir' of null  import/no-named-as-default
  1:1   warning  Resolve error: Cannot read property 'nuxtSrcDir' of null  import/no-named-as-default-member
```

## Solution

Instead of using default function parameters (which replace `undefined`, not `null`), use `||`.