### PR TITLE
Feature: rootDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,15 @@ Config is passed directly through to resolve as options:
 settings:
   import/resolver:
     nuxt:
-      # The path of nuxt resource directory to relative process.cwd() 
+      # The path of project root
+      # Useful if your project is part of a monorepo with multiple packages
+      # if unset, default is process.cwd()
+      rootDir: nuxt
+
+      # The path of nuxt resource directory to relative rootDir 
       # if unset, default is ''
       nuxtSrcDir: nuxt 
+	  
       extensions:
         # if unset, default is just '.js', but it must be re-added explicitly if set
         - .js

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ exports.interfaceVersion = 2;
 exports.resolve = function (source, file, config) {
   const trimmedSouce = trimResourceQuery(source)
   log('Resolving: ', trimmedSouce, 'from:', file);
-  const realSource = parseSource(trimmedSouce, config && config.nuxtSrcDir);
+  const realSource = parseSource(trimmedSouce, config && config.nuxtSrcDir, config && config.rootDir);
 
   if (resolve.isCore(realSource)) {
     log('resolved to core');
@@ -31,8 +31,8 @@ function trimResourceQuery(source) {
   return source
 }
 
-function parseSource(source, srcDir) {
-  const nuxtSrcDir = path.join(process.cwd(), srcDir || '');
+function parseSource(source, srcDir, rootDir) {
+  const nuxtSrcDir = path.join(rootDir || process.cwd(), srcDir || '');
   const nuxtAliasRe = /^~|@(assets|components|pages|plugins|static|store)?\/.+/;
   const nuxtFileAlias = ['~store', '~router', '@store', '@router'];
 

--- a/index.js
+++ b/index.js
@@ -4,9 +4,9 @@ const log = require('debug')('eslint-plugin-import:resolver:nuxt')
 
 exports.interfaceVersion = 2;
 exports.resolve = function (source, file, config) {
-  const trimmedSouce = trimResourceQuery(source)
-  log('Resolving: ', trimmedSouce, 'from:', file);
-  const realSource = parseSource(trimmedSouce, config && config.nuxtSrcDir, config && config.rootDir);
+  const trimmedSource = trimResourceQuery(source)
+  log('Resolving: ', trimmedSource, 'from:', file);
+  const realSource = parseSource(trimmedSource, config && config.nuxtSrcDir, config && config.rootDir);
 
   if (resolve.isCore(realSource)) {
     log('resolved to core');


### PR DESCRIPTION
**Feature**
Add a rootDir property to the config.

**Reason**
I have a Nuxt project that lives in a packages folder in a monorepo. When using ESLint in the root of the monorepo, it fails on the unresolved imports using the Nuxt aliases. This extra config setting fixes this. If not set, the original functionality is maintained.