### PR TITLE
fix: outdated(?) readme default extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,12 @@ settings:
       nuxtSrcDir: nuxt 
 	  
       extensions:
-        # if unset, default is just '.js', but it must be re-added explicitly if set
+        # if unset, default - '.mjs', '.js', '.json' and '.vue', but they must be re-added explicitly if set
         - .js
         - .jsx
+        - .json
+        - .vue
+        - .mjs
         - .es6
         - .coffee
 


### PR DESCRIPTION
You specified only '.js' in readme but have `'.mjs', '.js', '.json', '.vue'` in https://github.com/leiyaoqiang/eslint-import-resolver-nuxt/blob/2a34cbc87656c039289e58962d2b3ad0ac4256aa/index.js#L51