### PR TITLE
add handling for root dir alias and simplify regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,11 +32,19 @@ function trimResourceQuery(source) {
 }
 
 function parseSource(source, srcDir, rootDir) {
-  const nuxtSrcDir = path.join(rootDir || process.cwd(), srcDir || '');
-  const nuxtAliasRe = /^~|@(assets|components|pages|plugins|static|store)?\/.+/;
+  // directories
+  const nuxtRootDir = path.join(rootDir || process.cwd());
+  const nuxtSrcDir = path.join(nuxtRootDir, srcDir || '');
+
+  // patterns
+  const nuxtRootAliasRe = /^~~|@@\/.+/;
+  const nuxtSourceAliasRe = /^~|@\/.+/;
   const nuxtFileAlias = ['~store', '~router', '@store', '@router'];
 
-  if (nuxtAliasRe.test(source)) {
+  // switch
+  if (nuxtRootAliasRe.test(source)) {
+    return path.join(nuxtRootDir, source.slice(2))
+  } else if (nuxtSourceAliasRe.test(source)) {
     return path.join(nuxtSrcDir, source.slice(1));
   } else if (nuxtFileAlias.indexOf(source) !== -1) {
     return source.slice(1);


### PR DESCRIPTION
Building off https://github.com/leiyaoqiang/eslint-import-resolver-nuxt/pull/5, this PR adds handling for the `~~` and `@@` aliases as described in the [NuxtJS docs](https://nuxtjs.org/guide/directory-structure#aliases).

It also simplifies the source regex pattern by removing the optional directory names, which as far as I can tell were not necessary. It looks like they may have previously been used to capture specific subdirectories in a regex group?
